### PR TITLE
Update if statement for ValidateZipCode

### DIFF
--- a/src/ZipCoords.cs
+++ b/src/ZipCoords.cs
@@ -71,7 +71,7 @@ public partial class ZipCoords
             throw new ArgumentNullException(nameof(zipcode));
         }
 
-        if (zipcode.Length != 5 || zipcode.All(Char.IsNumber))
+        if (zipcode.Length != 5 || !zipcode.All(Char.IsNumber))
         {
             throw new ArgumentException($"'{zipcode}' is not a valid ZIP code");
         }


### PR DESCRIPTION
Update if statement so that error is only thrown if all characters are not a number. Currently, trying to use any zipcode results in an error. 